### PR TITLE
Move Hashable, Comparable conformance to DeclarationType.

### DIFF
--- a/Source/SourceKittenFramework/DeclarationType.swift
+++ b/Source/SourceKittenFramework/DeclarationType.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2015 SourceKitten. All rights reserved.
 //
 
-public protocol DeclarationType {
+public protocol DeclarationType: Hashable, Comparable {
     var language: Language { get }
     var kind: DeclarationKindType? { get }
     var location: SourceLocation { get }
@@ -16,5 +16,52 @@ public protocol DeclarationType {
     var usr: String? { get }
     var declaration: String? { get }
     var documentationComment: String? { get }
-    var children: [DeclarationType] { get }
+    var children: [AnyDeclarationType] { get }
+}
+
+// MARK: Hashable
+
+extension DeclarationType  {
+    public var hashValue: Int {
+        return usr?.hashValue ?? 0
+    }
+}
+
+public func ==(lhs: AnyDeclarationType, rhs: AnyDeclarationType) -> Bool {
+    return lhs.usr == rhs.usr &&
+        lhs.location == rhs.location
+}
+
+// MARK: Comparable
+
+/// A [strict total order](http://en.wikipedia.org/wiki/Total_order#Strict_total_order)
+/// over instances of `Self`.
+public func <(lhs: AnyDeclarationType, rhs: AnyDeclarationType) -> Bool {
+    return lhs.location < rhs.location
+}
+
+public struct AnyDeclarationType: DeclarationType {
+    public let language: Language
+    public let kind: DeclarationKindType?
+    public let location: SourceLocation
+    public let extent: Range<SourceLocation> // FIXME: Type 'SourceLocation' does not conform to protocol 'ForwardIndexType'
+    public let name: String?
+    public let typeName: String?
+    public let usr: String?
+    public let declaration: String?
+    public let documentationComment: String?
+    public let children: [AnyDeclarationType]
+    
+    init<T: DeclarationType>(_ declarationType: T) {
+        language = declarationType.language
+        kind = declarationType.kind
+        location = declarationType.location
+        extent = declarationType.extent
+        name = declarationType.name
+        typeName = declarationType.typeName
+        usr = declarationType.usr
+        declaration = declarationType.declaration
+        documentationComment = declarationType.documentationComment
+        children = declarationType.children
+    }
 }

--- a/Source/SourceKittenFramework/ObjCDeclaration.swift
+++ b/Source/SourceKittenFramework/ObjCDeclaration.swift
@@ -18,7 +18,7 @@ public struct ObjCDeclaration: DeclarationType {
     public let usr: String?
     public let declaration: String?
     public let documentationComment: String?
-    public let children: [DeclarationType]
+    public let children: [AnyDeclarationType]
     
     /// Returns the USR for the auto-generated getter for this property.
     ///

--- a/Source/SourceKittenFramework/ObjCDeclaration.swift
+++ b/Source/SourceKittenFramework/ObjCDeclaration.swift
@@ -87,24 +87,3 @@ extension SequenceType where Generator.Element == ObjCDeclaration {
         return filter { !propertyGetterSetterUSRs.contains($0.usr!) }
     }
 }
-
-// MARK: Hashable
-
-extension ObjCDeclaration: Hashable  {
-    public var hashValue: Int {
-        return usr?.hashValue ?? 0
-    }
-}
-
-public func ==(lhs: ObjCDeclaration, rhs: ObjCDeclaration) -> Bool {
-    return lhs.usr == rhs.usr &&
-        lhs.location == rhs.location
-}
-
-// MARK: Comparable
-
-/// A [strict total order](http://en.wikipedia.org/wiki/Total_order#Strict_total_order)
-/// over instances of `Self`.
-public func <(lhs: ObjCDeclaration, rhs: ObjCDeclaration) -> Bool {
-    return lhs.location < rhs.location
-}

--- a/Source/SourceKittenFramework/SwiftDeclaration.swift
+++ b/Source/SourceKittenFramework/SwiftDeclaration.swift
@@ -36,24 +36,3 @@ extension SwiftDeclaration {
         accessibility = // FIXME: Accessibility(rawValue: ...)
     }
 }
-
-// MARK: Hashable
-
-extension SwiftDeclaration: Hashable  {
-    public var hashValue: Int {
-        return usr?.hashValue ?? 0
-    }
-}
-
-public func ==(lhs: SwiftDeclaration, rhs: SwiftDeclaration) -> Bool {
-    return lhs.usr == rhs.usr &&
-        lhs.location == rhs.location
-}
-
-// MARK: Comparable
-
-/// A [strict total order](http://en.wikipedia.org/wiki/Total_order#Strict_total_order)
-/// over instances of `Self`.
-public func <(lhs: SwiftDeclaration, rhs: SwiftDeclaration) -> Bool {
-    return lhs.location < rhs.location
-}

--- a/Source/SourceKittenFramework/SwiftDeclaration.swift
+++ b/Source/SourceKittenFramework/SwiftDeclaration.swift
@@ -18,7 +18,7 @@ public struct SwiftDeclaration: DeclarationType {
     public let usr: String?
     public let declaration: String?
     public let documentationComment: String?
-    public let children: [DeclarationType]
+    public let children: [AnyDeclarationType]
     public let accessibility: Accessibility?
 }
 


### PR DESCRIPTION
As discussed in https://github.com/jpsim/SourceKitten/pull/112/files#r46729258.

This also adds `AnyDeclarationType` for reasons explained in https://github.com/jpsim/SourceKitten/pull/112/files#r46729614
